### PR TITLE
Add CI trigger for CCMM-utils synchronization

### DIFF
--- a/.github/workflows/trigger_utils.yml
+++ b/.github/workflows/trigger_utils.yml
@@ -1,0 +1,21 @@
+name: Trigger CCMM Utils Update
+
+on:
+  push:
+    branches:
+      - main
+    # run only if schemas are changed
+    paths:
+      - '**.xsd'
+
+jobs:
+  ping-utils:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit Repository Dispatch
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.DISPATCH_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/techlib/CCMM-utils/dispatches \
+          -d '{"event_type": "ccmm_xsd_updated"}'


### PR DESCRIPTION
This PR adds a GitHub Action that triggers an update in the techlib/CCMM-utils repository whenever XSD files in this repo are changed.